### PR TITLE
[stm32] adc_read_injected returns signed int

### DIFF
--- a/include/libopencm3/stm32/common/adc_common_v1.h
+++ b/include/libopencm3/stm32/common/adc_common_v1.h
@@ -372,7 +372,7 @@ void adc_set_right_aligned(uint32_t adc);
 bool adc_eoc(uint32_t adc);
 bool adc_eoc_injected(uint32_t adc);
 uint32_t adc_read_regular(uint32_t adc);
-uint32_t adc_read_injected(uint32_t adc, uint8_t reg);
+int32_t adc_read_injected(uint32_t adc, uint8_t reg);
 void adc_set_continuous_conversion_mode(uint32_t adc);
 void adc_set_single_conversion_mode(uint32_t adc);
 void adc_set_regular_sequence(uint32_t adc, uint8_t length, uint8_t channel[]);

--- a/include/libopencm3/stm32/f3/adc.h
+++ b/include/libopencm3/stm32/f3/adc.h
@@ -914,7 +914,7 @@ void adc_set_injected_sequence(uint32_t adc, uint8_t length, uint8_t channel[]);
 bool adc_eoc(uint32_t adc);
 bool adc_eoc_injected(uint32_t adc);
 uint32_t adc_read_regular(uint32_t adc);
-uint32_t adc_read_injected(uint32_t adc, uint8_t reg);
+int32_t adc_read_injected(uint32_t adc, uint8_t reg);
 void adc_set_injected_offset(uint32_t adc, uint8_t reg, uint32_t offset);
 
 void adc_set_clk_prescale(uint32_t prescaler);

--- a/lib/stm32/common/adc_common_v1.c
+++ b/lib/stm32/common/adc_common_v1.c
@@ -479,10 +479,10 @@ adc_set_injected_offset.
 
 @param[in] adc Unsigned int32. ADC block register address base @ref adc_reg_base
 @param[in] reg Unsigned int8. Register number (1 ... 4).
-@returns Unsigned int32 conversion result.
+@returns Signed int32 conversion result.
 */
 
-uint32_t adc_read_injected(uint32_t adc, uint8_t reg)
+int32_t adc_read_injected(uint32_t adc, uint8_t reg)
 {
 	switch (reg) {
 	case 1:

--- a/lib/stm32/f3/adc.c
+++ b/lib/stm32/f3/adc.c
@@ -771,10 +771,10 @@ uint32_t adc_read_regular(uint32_t adc)
  * @param[in] adc Unsigned int32. ADC block register address base @ref
  * adc_reg_base
  * @param[in] reg Unsigned int8. Register number (1 ... 4).
- * @returns Unsigned int32 conversion result.
+ * @returns Signed int32 conversion result.
  */
 
-uint32_t adc_read_injected(uint32_t adc, uint8_t reg)
+int32_t adc_read_injected(uint32_t adc, uint8_t reg)
 {
 	switch (reg) {
 	case 1:


### PR DESCRIPTION
Since reading an injected channel can apparently return negative values, the return type should probably be a signed int...